### PR TITLE
chore: complement macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+schema

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,20 @@
 use cosmwasm_std::{
     entry_point, from_json, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
 };
+use cosmwasm_schema::{cw_serde, QueryResponses};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cw_serde]
 pub struct InstantiateMsg {}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cw_serde]
 pub enum ExecuteMsg {
     Count,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct QueryMsg {}
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Counter {


### PR DESCRIPTION
We can generate this IDL, there are some missing traits and #[cw_serde] has them all

<img width="911" alt="image" src="https://github.com/FluxNFTLabs/wasmvm-counter/assets/30641530/6e4bd5f8-fc48-4282-bcf0-caf7392c87a8">
